### PR TITLE
UI 개선 및 사용자 경험 향상

### DIFF
--- a/src/App.jsx
+++ b/src/App.jsx
@@ -27,7 +27,7 @@ const theme = createTheme({
 
 function App() {
   const [currentTab, setCurrentTab] = useState('home')
-  const [currentPage, setCurrentPage] = useState('map') // 'home', 'map', 'community', 'mypage', 'auth'
+  const [currentPage, setCurrentPage] = useState('home') // 'home', 'map', 'community', 'mypage', 'auth'
 
   const renderCurrentPage = () => {
     switch (currentPage) {
@@ -73,7 +73,7 @@ function App() {
         position: 'relative',
       }}>
         {currentPage === 'auth' ? (
-          <AuthPage />
+          <AuthPage onNavigateToHome={handleNavigateToHome} />
         ) : (
           <>
             <Header onNavigateToAuth={handleNavigateToAuth} />

--- a/src/components/map/KakaoMap/KakaoMap.jsx
+++ b/src/components/map/KakaoMap/KakaoMap.jsx
@@ -679,7 +679,7 @@ function KakaoMap({
           disabled={locationLoading}
           sx={{
             position: 'absolute',
-            bottom: 16,
+            bottom: 50,
             right: 16,
             zIndex: 1000,
             bgcolor: 'white',

--- a/src/pages/Auth/AuthPage.jsx
+++ b/src/pages/Auth/AuthPage.jsx
@@ -1,13 +1,20 @@
 import { useState } from 'react'
-import { Box, Typography, Tabs, Tab, Paper } from '@mui/material'
+import { Box, Typography, Tabs, Tab, Paper, IconButton } from '@mui/material'
+import { ArrowBack } from '@mui/icons-material'
 import LoginForm from '../../components/auth/LoginForm/LoginForm'
 import RegisterForm from '../../components/auth/RegisterForm/RegisterForm'
 
-function AuthPage() {
+function AuthPage({ onNavigateToHome }) {
   const [tabValue, setTabValue] = useState(0)
 
   const handleTabChange = (event, newValue) => {
     setTabValue(newValue)
+  }
+
+  const handleBackToHome = () => {
+    if (onNavigateToHome) {
+      onNavigateToHome()
+    }
   }
 
   return (
@@ -37,6 +44,25 @@ function AuthPage() {
         textAlign: 'center',
         position: 'relative'
       }}>
+        {/* Back Button */}
+        <IconButton
+          onClick={handleBackToHome}
+          sx={{
+            position: 'absolute',
+            left: 16,
+            top: '50%',
+            transform: 'translateY(-50%)',
+            color: 'white',
+            bgcolor: 'rgba(255, 255, 255, 0.1)',
+            '&:hover': {
+              bgcolor: 'rgba(255, 255, 255, 0.2)'
+            }
+          }}
+          aria-label="홈으로 돌아가기"
+        >
+          <ArrowBack />
+        </IconButton>
+
         <Typography variant="h5" sx={{
           fontWeight: 700,
           mb: 1,

--- a/src/pages/Map/MapPage.jsx
+++ b/src/pages/Map/MapPage.jsx
@@ -135,7 +135,7 @@ function MapPage() {
       {/* Map Level Indicator */}
       <Box sx={{
         position: 'absolute',
-        bottom: 20,
+        bottom: 50,
         left: 16,
         zIndex: 1000,
         bgcolor: 'rgba(0, 0, 0, 0.7)',


### PR DESCRIPTION
## Summary
- 앱 초기 진입 시 홈 화면이 렌더링되도록 기본 페이지 설정 수정
- 로그인/회원가입 페이지에 뒤로가기 버튼 추가하여 홈 화면으로 이동 가능  
- 카카오맵 현위치 버튼과 줌레벨 표시란 위치를 위로 조정하여 하단 네비게이션과 겹치지 않도록 개선

## Changes Made
### App.jsx
- `currentPage` 초기값을 `'map'`에서 `'home'`으로 변경
- AuthPage에 `onNavigateToHome` 콜백 전달

### AuthPage.jsx  
- ArrowBack 아이콘과 IconButton import 추가
- `onNavigateToHome` prop 받도록 수정
- 헤더 영역에 뒤로가기 버튼 추가 (왼쪽 상단)

### KakaoMap.jsx
- 현위치 버튼의 `bottom` 값을 `16px`에서 `50px`로 조정

### MapPage.jsx
- 줌레벨 표시란의 `bottom` 값을 `20px`에서 `50px`로 조정

## Test plan
- [x] 앱 초기 진입 시 홈 화면 표시 확인
- [x] 로그인/회원가입 페이지에서 뒤로가기 버튼 작동 확인
- [x] 카카오맵 UI 요소들이 하단 네비게이션과 겹치지 않는지 확인

🤖 Generated with [Claude Code](https://claude.ai/code)