### PR TITLE
config: AWS 개발서버 백엔드 URL 설정

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,5 +1,5 @@
-# API Configuration - 백엔드가 8080 포트에서 실행됨
-VITE_API_URL=http://localhost:8080
+# API Configuration 
+VITE_API_URL=http://13.125.229.39:8080
 
 # Social Login Configuration
 # Google OAuth Client ID (from Google Cloud Console)
@@ -14,5 +14,5 @@ REACT_APP_KAKAO_API_KEY=your_kakao_api_key_here
 # Environment
 NODE_ENV=development
 
-# Port for development server
+# Port for development servercd
 PORT=3000

--- a/src/hooks/useKakaoAuth.js
+++ b/src/hooks/useKakaoAuth.js
@@ -5,7 +5,7 @@ export const useKakaoAuth = () => {
   const signInWithKakao = useCallback(() => {
     try {
       // 백엔드의 카카오 OAuth 시작 엔드포인트로 리다이렉트
-      const backendUrl = import.meta.env.VITE_API_URL || 'http://localhost:8080'
+      const backendUrl = import.meta.env.VITE_API_URL || 'http://13.125.229.39:8080'
       window.location.href = `${backendUrl}/auth/kakao/login`
     } catch (error) {
       console.error('카카오 로그인 리다이렉트 실패:', error)

--- a/src/services/api.js
+++ b/src/services/api.js
@@ -1,7 +1,7 @@
 import axios from 'axios'
 
 const api = axios.create({
-  baseURL: import.meta.env.VITE_API_URL || 'http://localhost:8080',
+  baseURL: import.meta.env.VITE_API_URL || 'http://13.125.229.39:8080',
   timeout: 10000,
 })
 


### PR DESCRIPTION
## Summary
프로젝트의 백엔드 API URL을 로컬호스트에서 AWS 개발서버 주소로 변경하여 개발 환경에서 실제 서버와 연동할 수 있도록 구성했습니다.

### 주요 변경사항
- **환경변수 설정**: `VITE_API_URL=http://13.125.229.39:8080`
- **API 서비스 기본값 변경**: axios 기본 URL을 AWS 개발서버로 설정
- **카카오 로그인 URL 변경**: 카카오 OAuth 리다이렉트를 AWS 백엔드로 설정

### 기술적 세부사항
- 환경변수가 있으면 해당 값 우선 사용
- 환경변수가 없으면 AWS 개발서버 주소를 기본값으로 사용
- 로컬 개발과 배포 환경 모두에서 일관된 동작 보장

### 파일 변경내역
- `.env.example`: AWS 개발서버 주소로 설정
- `src/services/api.js`: axios 기본 baseURL 변경
- `src/hooks/useKakaoAuth.js`: 카카오 로그인 백엔드 URL 변경

### 예상 효과
- 로컬 개발 환경에서 실제 백엔드와 연동하여 카카오 로그인 테스트 가능
- 개발서버에서 OAuth 플로우 전체 검증 가능
- 프로덕션 배포 전 완전한 기능 검증 가능

## Test plan
- [x] 코드 변경 완료
- [ ] 로컬에서 AWS 백엔드 연결 확인
- [ ] 카카오 로그인 플로우 테스트
- [ ] API 호출 정상 작동 확인
- [ ] 환경변수 우선순위 검증

🤖 Generated with [Claude Code](https://claude.ai/code)